### PR TITLE
chore: smoke gate test

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,5 @@ Mit dieser Struktur kann später automatisch geprüft werden:
 - Canonical data formats and schemas: `03_TCG/AUTHORING/`.
 
 PushEndpointTest: verify /git/push works
+
+SmokeGateTest: verify smoke-test gate


### PR DESCRIPTION
Changed: add SmokeGateTest marker line to README

Validation: /git/push ok:true; smoke-test ran and passed; upstream set; push succeeded

Risk: none (documentation-only)