### PR TITLE
chore: trim io test

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,5 @@ Mit dieser Struktur kann später automatisch geprüft werden:
 PushEndpointTest: verify /git/push works
 
 SmokeGateTest: verify smoke-test gate
+
+TrimIOTest: verify stdout/stderr truncation


### PR DESCRIPTION
Changed: add TrimIOTest marker line to README

Validation: /git/push ok:true, push succeeded

Risk: none (documentation-only)