### PR TITLE
chore: dev.ps1 skip starting uvicorn if already running

### DIFF
--- a/tools/dev.ps1
+++ b/tools/dev.ps1
@@ -12,6 +12,19 @@ Set-Location $RepoRoot
 
 Write-Host "[dev] RepoRoot: $RepoRoot"
 
+# If server is already running, do not start a second uvicorn
+$StatusUrl = "http://$BindHost`:$Port/git/status"
+try {
+  $r0 = Invoke-RestMethod -Method Get -Uri $StatusUrl -TimeoutSec 2
+  if ($r0.ok -eq $true) {
+    Write-Host "[dev] Server already running. /git/status ok:true (branch=$($r0.branch), dirty=$($r0.dirty))"
+    exit 0
+  }
+} catch {
+  # Not running yet -> continue with startup
+}
+
+
 # Optional venv detection (if you use one)
 $venvPython = Join-Path $RepoRoot ".venv\Scripts\python.exe"
 $python = if (Test-Path $venvPython) { $venvPython } else { "python" }


### PR DESCRIPTION
﻿## Changed
- dev.ps1 prüft /git/status vor Start; startet keinen zweiten Uvicorn-Prozess.

## Validation
- [x] /git/status ok:true
- [x] /git/push ok:true (feature branch)
- [ ] smoke-test passed (if applicable)

## Risk
- [x] none
- [ ] low
- [ ] medium
- [ ] high

## Notes
- 
