### PR TITLE
fix: default port 8001, robust repo check, Get-NetTCPConnection

### DIFF
--- a/tools/dev.ps1
+++ b/tools/dev.ps1
@@ -22,7 +22,7 @@ Usage:
 [CmdletBinding()]
 param(
   [string]$BindHost = "127.0.0.1",
-  [int]$Port = 8000,
+  [int]$Port = 8001,
 
   # Opens /docs after server is ready
   [switch]$Open,

--- a/tools/flow.ps1
+++ b/tools/flow.ps1
@@ -30,7 +30,7 @@ param(
   [string]$BindHost = "127.0.0.1",
 
   [Parameter()]
-  [int]$Port = 8000,
+  [int]$Port = 8001,
 
   [Parameter()]
   [int]$MaxWaitSec = 20,


### PR DESCRIPTION
﻿## Changed
- 

## Validation
- [ ] /git/status ok:true
- [ ] /git/push ok:true (feature branch)
- [ ] smoke-test passed (if applicable)

## Risk
- [ ] none
- [ ] low
- [ ] medium
- [ ] high

## Notes
- 
