### PR TITLE
fix: gh api comment body posting

### DIFF
--- a/.github/workflows/narrative-review.yml
+++ b/.github/workflows/narrative-review.yml
@@ -216,11 +216,17 @@ jobs:
           
           [ ! -f "$FILE" ] && exit 0
           
+          # Read comment body
+          BODY=$(cat "$FILE")
+          
           # Find existing comment
           EXISTING=$(gh api "repos/$REPO/issues/$PR/comments" --paginate | jq -r '.[] | select(.body | contains("<!-- NARRATIVE_REVIEW -->")) | .id' | head -1 || true)
           
+          # Build JSON payload with jq (handles escaping)
+          PAYLOAD=$(jq -n --arg body "$BODY" '{body:$body}')
+          
           if [ -n "$EXISTING" ]; then
-            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING" -f "body=@$FILE"
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING" --input - <<< "$PAYLOAD"
           else
-            gh api -X POST "repos/$REPO/issues/$PR/comments" -f "body=@$FILE"
+            gh api -X POST "repos/$REPO/issues/$PR/comments" --input - <<< "$PAYLOAD"
           fi


### PR DESCRIPTION
## Problem

Der Workflow hat erfolgreich getriggert und Chatti's Review generiert, **ABER** der `gh api` Befehl im "Post comment" Step hat nur den Dateipfad gepostet statt den Inhalt:

```
@.tmp_narrative_review/review_comment.md
```

**Root Cause:** `gh api -f body=@$FILE` wurde als literal string interpretiert, nicht als Datei-Referenz.

## Lösung

**Statt:**
```bash
gh api -f "body=@$FILE"  # Postet nur Filepath
```

**Jetzt:**
```bash
BODY=$(cat "$FILE")  # Lese File in Variable
PAYLOAD=$(jq -n --arg body "$BODY" '{body:$body}')  # Build JSON
gh api --input - <<< "$PAYLOAD"  # Post via stdin
```

## Changes

- ✅ Read comment file into bash variable
- ✅ Use `jq -n --arg` to build JSON payload (handles escaping)
- ✅ Pass JSON via stdin to `gh api` using `<<<`

## Testing

Wird validiert in PR #55 sobald gemerged.

---

**Ready to merge!** This fixes the comment posting and should finally show Chatti's actual review.