### PR TITLE
fix: correct OpenAI API payload type

### DIFF
--- a/.github/workflows/narrative-review.yml
+++ b/.github/workflows/narrative-review.yml
@@ -178,7 +178,7 @@ jobs:
               --arg content "$CONTENT" \
               --argjson temp "$TEMPERATURE" \
               --argjson maxtok "$MAX_TOKENS" \
-              '{model:$m, input:[{role:"user",content:[{type:"text",text:($prefix + "\n\n" + $content)}]}], temperature:$temp, max_output_tokens:$maxtok}')
+              '{model:$m, input:[{role:"user",content:[{type:"input_text",text:($prefix + "\n\n" + $content)}]}], temperature:$temp, max_output_tokens:$maxtok}')
             
             RESP=$(curl -w "\n%{http_code}" -sS \
               -H "Authorization: Bearer $OPENAI_API_KEY" \


### PR DESCRIPTION
## Problem

Workflow triggert erfolgreich und postet Kommentar, **ABER** OpenAI API gibt HTTP 400 Error:

```
Invalid value: 'text'. Supported values are: 'input_text', 'input_image', 'output_text', ...
```

**Root Cause:** Falscher `type` im API Payload. OpenAI Responses API erwartet `type:"input_text"` für Textinhalte, nicht `type:"text"`.

## Lösung

**Statt:**
```javascript
{type:"text", text:"..."}  // ❌ HTTP 400
```

**Jetzt:**
```javascript
{type:"input_text", text:"..."}  // ✅ Correct API format
```

## Changes

- ✅ Changed payload type from "text" to "input_text"
- ✅ Aligns with OpenAI Responses API specification

## Testing

Wird validiert in PR #55 sobald gemerged - sollte dann **echten** Chatti-Review liefern.

---

**Ready to merge!** Third time's the charm! 🎯