### PR TITLE
fix: parse output_text correctly from OpenAI Responses API

### DIFF
--- a/.github/workflows/narrative-review.yml
+++ b/.github/workflows/narrative-review.yml
@@ -195,11 +195,25 @@ jobs:
               continue
             fi
             
-            OUT=$(echo "$BODY" | jq -r '.output_text // ([.output[]?.content[]? | select(.type=="text") | .text] | join("\n")) // "No output"')
-            echo "" >> "$COMMENT"
-            echo "## ${FILE} — Batch ${BATCH}" >> "$COMMENT"
-            echo "" >> "$COMMENT"
-            echo "$OUT" >> "$COMMENT"
+            # FIXED: Correct parsing for output_text type
+            OUT=$(echo "$BODY" | jq -r '[.output[]? | select(.type=="message") | .content[]? | select(.type=="output_text") | .text] | join("\n\n")')
+            
+            # Handle incomplete responses
+            STATUS=$(echo "$BODY" | jq -r '.status // "complete"')
+            if [ "$STATUS" = "incomplete" ]; then
+              REASON=$(echo "$BODY" | jq -r '.incomplete_details.reason // "unknown"')
+              echo "" >> "$COMMENT"
+              echo "## ${FILE} — Batch ${BATCH}" >> "$COMMENT"
+              echo "" >> "$COMMENT"
+              echo "> ⚠️ **Response incomplete** (reason: ${REASON})" >> "$COMMENT"
+              echo "" >> "$COMMENT"
+              echo "$OUT" >> "$COMMENT"
+            else
+              echo "" >> "$COMMENT"
+              echo "## ${FILE} — Batch ${BATCH}" >> "$COMMENT"
+              echo "" >> "$COMMENT"
+              echo "$OUT" >> "$COMMENT"
+            fi
           done
 
       - name: Post comment


### PR DESCRIPTION
## Problem

API response parsing failed - output was empty even though API returned successfully.

**Root Cause:** 
- OpenAI Responses API returns `type: "output_text"`, not `type: "text"`
- We were searching for the wrong type in the jq filter

## Lösung

Fixed jq parsing to correctly extract text from API response structure:

```javascript
// OLD (broken):
.output[]?.content[]? | select(.type=="text") | .text

// NEW (fixed):
[.output[]? | select(.type=="message") | .content[]? | select(.type=="output_text") | .text] | join("\n\n")
```

## Changes

- ✅ Fixed output_text type parsing
- ✅ Added incomplete response handling (shows warning when max_output_tokens hit)
- ✅ Removed debug JSON output

---

**This is the FINAL fix! The workflow should now work end-to-end!** 🎉